### PR TITLE
Test with straight-to-curly-quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "jsdom": "^3.1.2",
+    "straight-to-curly-quotes": "^1.0.1",
     "tape": "^4.0.0",
     "uglify-js": "^2.4.19"
   }

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var jsdom = require('jsdom');
 var test = require('tape');
 var smartquotes = require('./');
+var quotesTests = require('straight-to-curly-quotes');
 
 test('smartquotes.string()', function (t) {
   var s = smartquotes.string;
@@ -16,6 +17,9 @@ test('smartquotes.string()', function (t) {
   t.equal(s('\'95'), '’95');
   t.equal(s('\'\'\''), '‴');
   t.equal(s('\'\''), '″');
+  quotesTests.forEach(function(test) {
+    t.equal(s(test.straight), test.curly);
+  });
 
   // needs test for backwards apostrophe, but not sure when it happens
 


### PR DESCRIPTION
This PR adds the tests published as [straight-to-curly-quotes](https://www.npmjs.com/package/straight-to-curly-quotes) to the test suite. The tests in that package are drawn from the current suite, Pandoc, and a couple books. There are a couple of internal-apostrophe tests that currently fail.

// @kellym @anseljh
