### PR TITLE
Update jsdom and get tests running on recent Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,11 @@
     "build": "cd src && uglifyjs smartquotes.js -o smartquotes.min.js --source-map smartquotes.min.js.map -c -m --comments '/Copyright/'"
   },
   "devDependencies": {
-    "jsdom": "^3.1.2",
+    "jsdom": "^7.0.0",
     "tape": "^4.0.0",
     "uglify-js": "^2.4.19"
+  },
+  "engines": {
+    "node" : ">=4.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -29,11 +29,7 @@ test('smartquotes.element()', function (t) {
   jsdom.env({
     file: 'demo/test.html',
     scripts: '../src/smartquotes.js',
-    loaded: function (err, window) {
-      if (err) {
-        throw err;
-      }
-
+    onload: function (window) {
       window.smartquotes.element(window.document.body);
 
       var one = window.document.getElementById('one');
@@ -53,11 +49,7 @@ test('smartquotes()', function (t) {
   jsdom.env({
     file: 'demo/test.html',
     scripts: '../src/smartquotes.js',
-    loaded: function (err, window) {
-      if (err) {
-        throw err;
-      }
-
+    onload: function (window) {
       var one = window.document.getElementById('one');
       var two = window.document.getElementById('two');
 


### PR DESCRIPTION
Now requires a Node >= 4, which was released 9/2015.

@kellym you may want to version bump / mention something in README if you decide to merge this; let me know if you'd like me to take care of that for you pre-merge.