### PR TITLE
Fixes single and double quote edge cases and adds double primes back

### DIFF
--- a/smartquotes.js
+++ b/smartquotes.js
@@ -36,7 +36,7 @@
   smartquotes.string = function(str) {
     return str
       .replace(/'''/g, '\u2034')                                                   // triple prime
-      .replace(/(\W|^)"(\S+)/g, '$1\u201c$2')                                       // beginning "
+      .replace(/(\W|^)"(\S+)/g, '$1\u201c$2')                                      // beginning "
       .replace(/(\u201c[^"]*)"([^"]*$|[^\u201c"]*\u201c)/g, '$1\u201d$2')          // ending "
       .replace(/([^0-9])"/g,'$1\u201d')                                            // remaining " at end of word
       .replace(/''/g, '\u2033')                                                    // double prime as two single quotes

--- a/smartquotes.js
+++ b/smartquotes.js
@@ -36,16 +36,17 @@
   smartquotes.string = function(str) {
     return str
       .replace(/'''/g, '\u2034')                                                   // triple prime
-      .replace(/(\W|^)"(\S)/g, '$1\u201c$2')                                       // beginning "
+      .replace(/(\W|^)"(\S+)/g, '$1\u201c$2')                                       // beginning "
       .replace(/(\u201c[^"]*)"([^"]*$|[^\u201c"]*\u201c)/g, '$1\u201d$2')          // ending "
       .replace(/([^0-9])"/g,'$1\u201d')                                            // remaining " at end of word
-      .replace(/''/g, '\u2033')                                                    // double prime
+      .replace(/''/g, '\u2033')                                                    // double prime as two single quotes
       .replace(/(\W|^)'(\S)/g, '$1\u2018$2')                                       // beginning '
       .replace(/([a-z])'([a-z])/ig, '$1\u2019$2')                                  // conjunction's possession
       .replace(/((\u2018[^']*)|[a-z])'([^0-9]|$)/ig, '$1\u2019$3')                 // ending '
       .replace(/(\u2018)([0-9]{2}[^\u2019]*)(\u2018([^0-9]|$)|$|\u2019[a-z])/ig, '\u2019$2$3')     // abbrev. years like '93
-      .replace(/(\B|^)\u2018(?=([^\u2019]*\u2019\b)*([^\u2019\u2018]*\W[\u2019\u2018]\b|[^\u2019\u2018]*$))/ig, '$1\u2019') // backwards apostrophe
-      .replace(/'/g, '\u2032');
+      .replace(/(\B|^)\u2018(?=([^\u2018\u2019]*\u2019\b)*([^\u2019\u2018]*\W[\u2019\u2018]\b|[^\u2019\u2018]*$))/ig, '$1\u2019') // backwards apostrophe
+      .replace(/"/g, '\u2033')                                                     // double prime
+      .replace(/'/g, '\u2032');                                                    // prime
   };
 
   smartquotes.element = function(root) {

--- a/test/smartquotes.js
+++ b/test/smartquotes.js
@@ -4,17 +4,20 @@ var smartquotes = require('../');
 
 test('smartquotes.string()', function (t) {
   var s = smartquotes.string;
-  t.equal(s('"test"'), '“test”');
-  t.equal(s('the—"test"'), 'the—“test”');
-  t.equal(s('\'test\''), '‘test’');
-  t.equal(s('ma\'am'), 'ma’am');
-  t.equal(s('\'em'), '’em');
-  t.equal(s('Marshiness of \'Ammercloth\'s'), 'Marshiness of ’Ammercloth’s');
-  t.equal(s('\'95'), '’95');
-  t.equal(s('\'\'\''), '‴');
-  t.equal(s('\'\''), '″');
-
-  // needs test for backwards apostrophe, but not sure when it happens
+  t.equal(s('"test"'), '\u201ctest\u201d');
+  t.equal(s('the\u2014 "test"'), 'the\u2014 \u201ctest\u201d');
+  t.equal(s('\'test\''), '\u2018test\u2019');
+  t.equal(s('ma\'am'), 'ma\u2019am');
+  t.equal(s('\'em'), '\u2019em');
+  t.equal(s('Marshiness of \'Ammercloth\'s'), 'Marshiness of \u2019Ammercloth\u2019s');
+  t.equal(s('\'95'), '\u201995');
+  t.equal(s('\'\'\''), '\u2034');
+  t.equal(s('\'\''), '\u2033');
+  t.equal(s('"Better than a 6\'5" whale."'), '\u201cBetter than a 6\u20325\u2033 whale.\u201d');
+  t.equal(s('"It\'s my \'#1\' choice!" - 12" Foam Finger from \'93'), '\u201cIt\u2019s my \u2018#1\u2019 choice!\u201d - 12\u2033 Foam Finger from \u201993');
+  t.equal(s('"Say \'what?\'" says a Mill\'s Pet Barn employee.'), '\u201cSay \u2018what?\u2019\u201d says a Mill\u2019s Pet Barn employee.');
+  t.equal(s('"Quote?": Description'), '\u201cQuote?\u201d: Description');
+  t.equal(s('\'Quote?\': Description'), '\u2018Quote?\u2019: Description');
 
   // All synchronous, no need for t.plan()
   t.end();
@@ -30,13 +33,13 @@ test('smartquotes.element()', function (t) {
       window.smartquotes.element(window.document.body);
 
       var one = window.document.getElementById('one');
-      t.equal(one.innerHTML, 'Ma’am, this “test” is from ’95');
+      t.equal(one.innerHTML, 'Ma\u2019am, this \u201ctest\u201d is from \u201995');
 
       var two = window.document.getElementById('two');
-      t.equal(two.innerHTML, 'Marshiness of ’Ammercloth’s');
+      t.equal(two.innerHTML, 'Marshiness of \u2019Ammercloth\u2019s');
 
       var three = window.document.getElementById('three');
-      t.equal(three.innerHTML, '<p>“This ‘text with an inner <em>emphasis</em>’ should be smart, too.</p><p>“Super smart.”</p>');
+      t.equal(three.innerHTML, '<p>\u201cThis \u2018text with an inner <em>emphasis</em>\u2019 should be smart, too.</p><p>\u201cSuper smart.\u201d</p>');
     }
   });
 });
@@ -44,7 +47,7 @@ test('smartquotes.element()', function (t) {
 test('smartquotes()', function (t) {
   t.plan(4);
 
-  t.equal(smartquotes('"test"'), '“test”');
+  t.equal(smartquotes('"test"'), '\u201ctest\u201d');
 
   jsdom.env({
     file: './test/fixtures/basic.html',
@@ -54,11 +57,11 @@ test('smartquotes()', function (t) {
       var two = window.document.getElementById('two');
 
       window.smartquotes(one);
-      t.equal(one.innerHTML, 'Ma’am, this “test” is from ’95');
+      t.equal(one.innerHTML, 'Ma\u2019am, this \u201ctest\u201d is from \u201995');
       t.equal(two.innerHTML, 'Marshiness of \'Ammercloth\'s');
 
       window.smartquotes();
-      t.equal(two.innerHTML, 'Marshiness of ’Ammercloth’s');
+      t.equal(two.innerHTML, 'Marshiness of \u2019Ammercloth\u2019s');
     }
   });
 });


### PR DESCRIPTION
This resolves three main issues:

- incorrect single quotes when another single quote is found later in the string
- incorrect end double quote when there are multiple non-word characters in a row
- previously removed support for converting remaining double quotes to double primes

Fixes #18. 
Fixes #19.