### PR TITLE
Adds support for parse5 parsed documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "jsdom": "^7.0.0",
+    "parse5": "^3.0.2",
     "tap": "^10.3.0"
   },
   "engines": {

--- a/smartquotes.js
+++ b/smartquotes.js
@@ -68,9 +68,9 @@
       for (i = 0; i < childNodes.length; i++) {
         node = childNodes[i];
 
-        if (node.nodeType === TEXT_NODE) {
+        if (node.nodeType === TEXT_NODE || node.nodeName === '#text') {
           textNodes.push([node, text.length]);
-          text += node.nodeValue;
+          text += node.nodeValue || node.value;
         } else if (node.childNodes && node.childNodes.length) {
           text += handleElement(node);
         }
@@ -81,6 +81,8 @@
         var nodeInfo = textNodes[i];
         if (nodeInfo[0].nodeValue) {
           nodeInfo[0].nodeValue = text.substr(nodeInfo[1], nodeInfo[0].nodeValue.length);
+        } else if (nodeInfo[0].value) {
+          nodeInfo[0].value = text.substr(nodeInfo[1], nodeInfo[0].value.length);
         }
       }
       return text;

--- a/test/smartquotes.js
+++ b/test/smartquotes.js
@@ -1,5 +1,6 @@
 var jsdom = require('jsdom');
 var test = require('tap').test;
+var parse5 = require('parse5');
 var smartquotes = require('../');
 
 // a list of test strings and expected converted values
@@ -74,4 +75,11 @@ test('smartquotes()', function (t) {
       t.equal(two.innerHTML, 'Marshiness of \u2019Ammercloth\u2019s');
     }
   });
+});
+
+test('parse5 support with smartquotes.element', function(t) {
+  var document = parse5.parse('"test text"');
+  smartquotes.element(document);
+  t.match(parse5.serialize(document), /\u201ctest text\u201d/);
+  t.end();
 });


### PR DESCRIPTION
This adds support for parse5 parsed documents to be able to be passed in to smartquotes.  The main differences here are that parse5 uses the node name “#text” as the reference to text nodes, as opposed to a node type, and `value` is used instead of `nodeValue`.