### PR TITLE
Fix text breaks

### DIFF
--- a/smartquotes.js
+++ b/smartquotes.js
@@ -33,13 +33,13 @@
     }
   }
 
-  smartquotes.string = function(str) {
+  smartquotes.string = function(str, retainLength) {
     return str
-      .replace(/'''/g, '\u2034')                                                   // triple prime
-      .replace(/(\W|^)"(\w)/g, '$1\u201c$2')                                      // beginning "
+      .replace(/'''/g, '\u2034' + (retainLength ? '\u2063\u2063' : ''))            // triple prime
+      .replace(/(\W|^)"(\w)/g, '$1\u201c$2')                                       // beginning "
       .replace(/(\u201c[^"]*)"([^"]*$|[^\u201c"]*\u201c)/g, '$1\u201d$2')          // ending "
       .replace(/([^0-9])"/g,'$1\u201d')                                            // remaining " at end of word
-      .replace(/''/g, '\u2033')                                                    // double prime as two single quotes
+      .replace(/''/g, '\u2033' + (retainLength ? '\u2063' : ''))                   // double prime as two single quotes
       .replace(/(\W|^)'(\S)/g, '$1\u2018$2')                                       // beginning '
       .replace(/([a-z])'([a-z])/ig, '$1\u2019$2')                                  // conjunction's possession
       .replace(/(\u2018)([0-9]{2}[^\u2019]*)(\u2018([^0-9]|$)|$|\u2019[a-z])/ig, '\u2019$2$3')     // abbrev. years like '93
@@ -59,7 +59,7 @@
         return;
       }
 
-      var i, node;
+      var i, node, nodeInfo;
       var childNodes = el.childNodes;
       var textNodes = [];
       var text = '';
@@ -76,16 +76,20 @@
         }
 
       }
-      text = smartquotes.string(text);
+      text = smartquotes.string(text, true);
       for (i in textNodes) {
-        var nodeInfo = textNodes[i];
+        nodeInfo = textNodes[i];
         if (nodeInfo[0].nodeValue) {
-          nodeInfo[0].nodeValue = text.substr(nodeInfo[1], nodeInfo[0].nodeValue.length);
+          nodeInfo[0].nodeValue = substring(text, nodeInfo[0].nodeValue, nodeInfo[1]);
         } else if (nodeInfo[0].value) {
-          nodeInfo[0].value = text.substr(nodeInfo[1], nodeInfo[0].value.length);
+          nodeInfo[0].value = substring(text, nodeInfo[0].value, nodeInfo[1]);
         }
       }
       return text;
+    }
+
+    function substring(text, value, position) {
+      return text.substr(position, value.length).replace('\u2063', '');
     }
 
     return root;

--- a/test/fixtures/basic.html
+++ b/test/fixtures/basic.html
@@ -9,8 +9,8 @@
 <p id="two">Marshiness of 'Ammercloth's</p>
 <div id="three"><p>"This 'text with an inner <em>emphasis</em>' should be smart, too.</p><p>"Super smart."</p></div>
 <div id="four">
-  <p>"Die krijg je van ons'', probeert John Williams nog. "Ik vind het niet mooi."</p>
-  <h4>Veilingsite</h4>
+  "Die krijg je van ons'', probeert John Williams nog.
+  <br />Maar Mees keurt alle verbeteringen met een verbeten gezicht volledig af. "Ik vind het niet mooi."
 </div>
 </body>
 </html>

--- a/test/fixtures/basic.html
+++ b/test/fixtures/basic.html
@@ -8,6 +8,9 @@
 <p id="one">Ma'am, this "test" is from '95</p>
 <p id="two">Marshiness of 'Ammercloth's</p>
 <div id="three"><p>"This 'text with an inner <em>emphasis</em>' should be smart, too.</p><p>"Super smart."</p></div>
-
+<div id="four">
+  <p>"Die krijg je van ons'', probeert John Williams nog. "Ik vind het niet mooi."</p>
+  <h4>Veilingsite</h4>
+</div>
 </body>
 </html>

--- a/test/smartquotes.js
+++ b/test/smartquotes.js
@@ -43,17 +43,19 @@ test('smartquotes.element()', (t) => {
     onload: function (window) {
       window.smartquotes.element(window.document.body);
 
+      // should convert basic types of quotes to smart quotes
       var one = window.document.getElementById('one');
-      t.equal(one.innerHTML, 'Ma\u2019am, this \u201ctest\u201d is from \u201995');
-
       var two = window.document.getElementById('two');
+      t.equal(one.innerHTML, 'Ma\u2019am, this \u201ctest\u201d is from \u201995');
       t.equal(two.innerHTML, 'Marshiness of \u2019Ammercloth\u2019s');
 
+      // should handle tags inside tags
       var three = window.document.getElementById('three');
       t.equal(three.innerHTML, '<p>\u201cThis \u2018text with an inner <em>emphasis</em>\u2019 should be smart, too.</p><p>\u201cSuper smart.\u201d</p>');
 
+      // should retain proper substrings inside tag
       var four = window.document.getElementById('four');
-      t.match(four.innerHTML, 'Veilingsite');
+      t.match(four.innerHTML, 'Maar Mees');
     }
   });
 });

--- a/test/smartquotes.js
+++ b/test/smartquotes.js
@@ -35,7 +35,7 @@ test('smartquotes.string()', (t) => {
 });
 
 test('smartquotes.element()', (t) => {
-  t.plan(3);
+  t.plan(4);
 
   jsdom.env({
     file: './test/fixtures/basic.html',
@@ -51,6 +51,9 @@ test('smartquotes.element()', (t) => {
 
       var three = window.document.getElementById('three');
       t.equal(three.innerHTML, '<p>\u201cThis \u2018text with an inner <em>emphasis</em>\u2019 should be smart, too.</p><p>\u201cSuper smart.\u201d</p>');
+
+      var four = window.document.getElementById('four');
+      t.match(four.innerHTML, 'Veilingsite');
     }
   });
 });


### PR DESCRIPTION
When double and triple primes were replaced, the text length changed, which affected the offset at which text was replaced in an HTML document.  This wasn’t initially apparent because typically a space is usually the character to be shifted. 

This fixes the issue and adds a test to ensure this behavior is retained.

Fixes #25.