### PR TITLE
Remove trailing comma in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
     "**/.*",
     "node_modules",
     "bower_components",
-    "test",
+    "test"
   ]
 }


### PR DESCRIPTION
I was having issues installing smartquotes with `bower install` on node 5. Removing the trailing comma in bower.json seems to have fixed it.