### PR TITLE
Convert double dashes to em dashes

### DIFF
--- a/smartquotes.js
+++ b/smartquotes.js
@@ -46,7 +46,8 @@
       .replace(/((\u2018[^']*)|[a-z])'([^0-9]|$)/ig, '$1\u2019$3')                 // ending '
       .replace(/(\B|^)\u2018(?=([^\u2018\u2019]*\u2019\b)*([^\u2018\u2019]*\B\W[\u2018\u2019]\b|[^\u2018\u2019]*$))/ig, '$1\u2019') // backwards apostrophe
       .replace(/"/g, '\u2033')                                                     // double prime
-      .replace(/'/g, '\u2032');                                                    // prime
+      .replace(/'/g, '\u2032')                                                     // prime
+      .replace(/\-\-/g, '\u2014');                                                 // em dash
   };
 
   smartquotes.element = function(root) {

--- a/test/smartquotes.js
+++ b/test/smartquotes.js
@@ -22,7 +22,8 @@ test('smartquotes.string()', t => {
     '"Quote?": Description': '\u201cQuote?\u201d: Description',
     '\'Quo Te?\': Description': '\u2018Quo Te?\u2019: Description',
     '"De Poesjes van Kevin?": Something, something': '\u201cDe Poesjes van Kevin?\u201d: Something, something',
-    'And then she blurted, "I thought you said, \'I don\'t like \'80s music\'?"': "And then she blurted, \u201cI thought you said, \u2018I don\u2019t like \u201980s music\u2019?\u201d"
+    'And then she blurted, "I thought you said, \'I don\'t like \'80s music\'?"': "And then she blurted, \u201cI thought you said, \u2018I don\u2019t like \u201980s music\u2019?\u201d",
+    'Oh wow -- these are em dashes - how cool --- ----': 'Oh wow \u2014 these are em dashes - how cool \u2014- \u2014\u2014'
   };
 
   Object.keys(expectations).forEach( string => {


### PR DESCRIPTION
This doesn't handle en dashes, instead replacing -- with — everywhere. It suits my use case, but not sure if it's general enough for anyone to use. For example, it looks like LaTeX has the following behavior:

* `-` is hyphen
* `--` is en dash
* `---` is em dash 